### PR TITLE
%Import QtXml/QtXmlmod.sip if available

### DIFF
--- a/poppler-qt5.sip
+++ b/poppler-qt5.sip
@@ -5,11 +5,13 @@
  * Maintained by Wilbert Berendsen <wbsoft@xs4all.nl>
  */
 
+%Feature QTXML_AVAILABLE
 
 %Import QtCore/QtCoremod.sip
 %Import QtGui/QtGuimod.sip
-
-%Feature QTXML_AVAILABLE
+%If(QTXML_AVAILABLE)
+%Import QtXml/QtXmlmod.sip
+%End
 
 %Timeline {
     POPPLER_V0_20_0


### PR DESCRIPTION
to fix `sip: QDomElement is undefined` error.

Fixes #2