### PR TITLE
Fix typo: higlight -> highlight

### DIFF
--- a/poppler-annotation.sip
+++ b/poppler-annotation.sip
@@ -527,7 +527,7 @@ class HighlightAnnotation : Poppler::Annotation
 %Docstring
 Text highlight annotation.
 
-The higlight annotation represents some areas of text being "highlighted".
+The highlight annotation represents some areas of text being "highlighted".
 %End
 %TypeHeaderCode
 #include <qt5/poppler-qt5.h>


### PR DESCRIPTION
Found by the Debian Lintian tool